### PR TITLE
Update element offset computation

### DIFF
--- a/src/js/dom/manipulator.js
+++ b/src/js/dom/manipulator.js
@@ -96,8 +96,8 @@ const Manipulator = {
     const rect = element.getBoundingClientRect();
 
     return {
-      top: rect.top + document.body.scrollTop,
-      left: rect.left + document.body.scrollLeft,
+      top: rect.top + Math.max(document.body.scrollTop, document.documentElement.scrollTop, window.scrollY),
+      left: rect.left + Math.max(document.body.scrollLeft, document.documentElement.scrollLeft, window.scrollX),
     };
   },
 


### PR DESCRIPTION
Updated logic for computing element top and left offset to use document.documentElement and window, from document.body since document.body always returns 0